### PR TITLE
Remove rpi5 uart hack

### DIFF
--- a/arch/arm/dts/bcm283x-u-boot.dtsi
+++ b/arch/arm/dts/bcm283x-u-boot.dtsi
@@ -38,3 +38,11 @@
 &gpio {
 	bootph-all;
 };
+
+&uart0_gpio14 {
+	bootph-all;
+};
+
+&uart1_gpio14 {
+	bootph-all;
+};


### PR DESCRIPTION
We are removing the hack from commit https://github.com/emteria/external_u-boot_rpi/commit/f63eeb6fc08d5c731195685e171f20c8552da386#diff-c0a0f6594023fa9702f43f1a73028eab2afacc4ba09667ba2da1ec4506d4ad3eL43 which was needed when we implemnted support for rpi5. This is the definition for the UART GPIO Pins on RPi4. 